### PR TITLE
Version 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] / 2024-01-26
+- Remove `IFrameworkElementCreator` that is not necessary.
+- The Revit version could be 2017 without `IFrameworkElementCreator` reference.
+
 ## [1.0.1] / 2024-01-17 - 2024-01-26
 - Add `DockablePaneProviderCreator`
 - Add `DockablePaneCreatorService` with auto `Visibility` event in the `FrameworkElement`.
@@ -16,5 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Views`
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.2]: ../../compare/1.0.1...1.0.2
 [1.0.1]: ../../compare/1.0.0...1.0.1
 [1.0.0]: ../../compare/1.0.0

--- a/RevitAddin.Dockable.Example/Revit/DockablePaneHideWhenFamilyDocument.cs
+++ b/RevitAddin.Dockable.Example/Revit/DockablePaneHideWhenFamilyDocument.cs
@@ -7,7 +7,7 @@ namespace RevitAddin.Dockable.Example.Revit
     {
         public void DockablePaneChanged(DockablePaneDocumentData data)
         {
-            Console.WriteLine($"{data.DockablePaneId.Guid} \t {data.DockablePane.TryGetTitle()} - {data.DockablePane.TryIsShown()} \t {data.Document?.Title} \t {data.FrameworkElement}");
+            //Console.WriteLine($"{data.DockablePaneId.Guid} \t {data.DockablePane.TryGetTitle()} - {data.DockablePane.TryIsShown()} \t {data.Document?.Title} \t {data.FrameworkElement}");
 
             var isFamilyDocument = data.Document?.IsFamilyDocument == true;
 

--- a/RevitAddin.Dockable.Example/RevitAddin.Dockable.Example.csproj
+++ b/RevitAddin.Dockable.Example/RevitAddin.Dockable.Example.csproj
@@ -85,7 +85,7 @@
 
   <PropertyGroup>
     <PackageId>RevitAddin.Dockable.Example</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <ProjectGuid>{37680B66-998C-46DB-BD30-911299820F2C}</ProjectGuid>
   </PropertyGroup>
 

--- a/RevitAddin.Dockable.Example/Services/DockablePaneProviderCreator.cs
+++ b/RevitAddin.Dockable.Example/Services/DockablePaneProviderCreator.cs
@@ -6,21 +6,12 @@ namespace RevitAddin.Dockable.Example.Services
 {
     internal class DockablePaneProviderCreator : IDockablePaneProvider
     {
-        private readonly IFrameworkElementCreator frameworkElementCreator;
+        private readonly FrameworkElement frameworkElement;
         private readonly IDockablePaneProvider dockablePaneProvider;
 
-        public DockablePaneProviderCreator(IFrameworkElementCreator frameworkElementCreator)
-        {
-            this.frameworkElementCreator = frameworkElementCreator;
-        }
-
-        public DockablePaneProviderCreator(IFrameworkElementCreator frameworkElementCreator, IDockablePaneProvider dockablePaneProvider) : this(frameworkElementCreator)
-        {
-            this.dockablePaneProvider = dockablePaneProvider;
-        }
         public DockablePaneProviderCreator(FrameworkElement frameworkElement)
         {
-            this.frameworkElementCreator = new FrameworkElementCreator(frameworkElement);
+            this.frameworkElement = frameworkElement;
         }
 
         public DockablePaneProviderCreator(FrameworkElement frameworkElement, IDockablePaneProvider dockablePaneProvider) : this(frameworkElement)
@@ -31,22 +22,7 @@ namespace RevitAddin.Dockable.Example.Services
         public void SetupDockablePane(DockablePaneProviderData data)
         {
             dockablePaneProvider?.SetupDockablePane(data);
-            data.FrameworkElementCreator = frameworkElementCreator;
-            data.FrameworkElement = null;
-        }
-
-        class FrameworkElementCreator : IFrameworkElementCreator
-        {
-            private readonly FrameworkElement frameworkElement;
-
-            public FrameworkElementCreator(FrameworkElement frameworkElement)
-            {
-                this.frameworkElement = frameworkElement;
-            }
-            public FrameworkElement CreateFrameworkElement()
-            {
-                return frameworkElement;
-            }
+            data.FrameworkElement = frameworkElement;
         }
     }
 }

--- a/RevitAddin.Dockable.Example/Views/DockablePage.xaml.cs
+++ b/RevitAddin.Dockable.Example/Views/DockablePage.xaml.cs
@@ -20,11 +20,10 @@ namespace RevitAddin.Dockable.Example.Views
 
         public void SetupDockablePane(DockablePaneProviderData data)
         {
-            data.FrameworkElement = this;
-
+            data.VisibleByDefault = true;
             data.InitialState = new DockablePaneState
             {
-                DockPosition = DockPosition.Tabbed,
+                DockPosition = DockPosition.Bottom,
             };
         }
 


### PR DESCRIPTION
- Remove `IFrameworkElementCreator` that is not necessary.
- The Revit version could be 2017 without `IFrameworkElementCreator` reference.